### PR TITLE
change oid lookup for signing

### DIFF
--- a/src/AS2Crypto/AS2SignedData.ts
+++ b/src/AS2Crypto/AS2SignedData.ts
@@ -111,13 +111,7 @@ export class AS2SignedData {
   }
 
   private _getCertAlgorithmId (certificate: any) {
-    const rsaPssId = new ObjectID({ name: 'RSA-PSS' }).id
-
-    if (certificate.signatureAlgorithm.algorithmId === rsaPssId) {
-      return rsaPssId
-    }
-
-    return certificate.subjectPublicKeyInfo.algorithm.algorithmId
+    return certificate.signatureAlgorithm.algorithmId;
   }
 
   private async _addSigner ({ cert, key, algorithm }: SignMethodOptions) {


### PR DESCRIPTION
When pulling the OID from SubjectPublicKeyInfo, we can get values like rsaEncryption (1.2.840.113549.1.1) which breaks @peculiar/webcrypto. Their docs indicate This one should not be used for signing. 

I don't know enough to say if this is safer, but it appears to be working when testing with a key/cert generated this way:

> openssl version
OpenSSL 3.0.5 5 Jul 2022 (Library: OpenSSL 3.0.5 5 Jul 2022)
> openssl req -nodes -new -x509 -keyout test.key -out test.cer
> openssl asn1parse -in test.cer -item X509 | grep algorithm
      algorithm: sha256WithRSAEncryption (1.2.840.113549.1.1.11)
        algorithm: rsaEncryption (1.2.840.113549.1.1.1)
    algorithm: sha256WithRSAEncryption (1.2.840.113549.1.1.11)